### PR TITLE
Discontinuation of GooseMod

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@ GMI is a simple goosemod installer (mainly to test Eel)
 
 <img src="https://media.discordapp.net/attachments/846891636873363467/979213819815559178/unknown.png"/>
 
-# build
 
+# Archived
+GooseMod is now discontinued as of September 27th, and is no longer usable.
+[OpenAsar](https://openasar.dev/) is a possible alternative.
+
+
+# How to Build
 cd src<br/>
 pip install -r requirements.txt<br/><br/>
 


### PR DESCRIPTION
GooseMod discontinued on September 27th. No longer usable.
